### PR TITLE
I've added a new page for usage precautions and updated the links.

### DIFF
--- a/caution/index.html
+++ b/caution/index.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="テンプレートの概要とダウンロード案内">
+
+    <!-- favicon -->
+    <link href="../assets/img/common/favicon.ico" type="image/x-icon" rel="icon">
+
+    <!-- Google Tag Manager -->
+    <script>
+        (function (w, d, s, l, i) {
+            w[l] = w[l] || []; w[l].push({
+                'gtm.start': new Date().getTime(),
+                event: 'gtm.js'
+            });
+            var f = d.getElementsByTagName(s)[0],
+                j = d.createElement(s),
+                dl = l != 'dataLayer' ? '&l=' + l : '';
+            j.async = true;
+            j.src =
+                'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
+            f.parentNode.insertBefore(j, f);
+        })(window, document, 'script', 'dataLayer', 'GTM-KK37GB');
+    </script>
+    <!-- End Google Tag Manager -->
+
+    <title>使用上の注意 - マニュアルテンプレート</title>
+    <link rel="stylesheet" href="../assets/css/styles.css">
+    <!-- Swiper.jsのCSS -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.css">
+</head>
+<body>
+    <header>
+        <div>
+            <div class="">
+                <div class="header">
+                    <h1>マニュアルテンプレート<br>ダウンロード</h1>
+                    <div class="header-box">
+                        <a href="https://www.kwix.co.jp/" target="_blank">株式会社クイックス</a><br>
+                        <span>使用上の注意</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </header>
+
+    <div class="breadcrumb">
+        <a href="../index.html">ホーム</a> &gt; 使用上の注意
+    </div>
+
+    <div class="content">
+        <section>
+            <h1>使用上の注意</h1>
+            <h2>利用上の注意</h2>
+            <ul>
+                <li>ここに利用上の注意を記載します。</li>
+            </ul>
+            <h2>免責事項</h2>
+            <ul>
+                <li>ここに免責事項を記載します。</li>
+            </ul>
+            <h2>著作権</h2>
+            <ul>
+                <li>ここに著作権を記載します。</li>
+            </ul>
+        </section>
+    </div>
+
+    <footer>
+        <div class="host-info">
+            <p>Copyright Kwix.co.LTD　ALL RIGHTS RESERVED</p>
+            <p><a href="https://www.kwix.co.jp/" target="_blank">https://www.kwix.co.jp/</a></p>
+        </div>
+    </footer>
+
+    <script src="../assets/js/jquery-3.6.0.min.js"></script>
+    <script src="../assets/js/modal.js"></script>
+    <script src="../assets/js/swiper-init.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.js"></script>
+    <script src="../assets/js/accordion.js"></script>
+</body>
+</html>

--- a/howto/checklist/manual-checklist/index.html
+++ b/howto/checklist/manual-checklist/index.html
@@ -39,7 +39,7 @@
                     <h1><a href="../../../index.html">マニュアルテンプレート<br>ダウンロード</a></h1>
                     <div class="header-box">
                         <a href="https://www.kwix.co.jp/" target="_blank">株式会社クイックス</a><br>
-                        <a href="">使用上の注意</a>
+                        <a href="../../../caution/index.html">使用上の注意</a>
                     </div>
                 </div>
             </div>

--- a/howto/guidelines/clear-manual/index.html
+++ b/howto/guidelines/clear-manual/index.html
@@ -43,7 +43,7 @@
             </h1>
             <div class="header-box">
               <a href="https://www.kwix.co.jp/" target="_blank">株式会社クイックス</a><br />
-              <a href="">使用上の注意</a>
+                        <a href="../../../caution/index.html">使用上の注意</a>
             </div>
           </div>
         </div>

--- a/howto/guidelines/document-improve/index.html
+++ b/howto/guidelines/document-improve/index.html
@@ -39,7 +39,7 @@
         <div class="header">
           <h1><a href="../../../index.html">マニュアルテンプレート<br>ダウンロード</a></h1>
           <div class="header-box"><a href="https://www.kwix.co.jp/" target="_blank">株式会社クイックス</a><br>
-            <a href="">使用上の注意</a>
+            <a href="../../../caution/index.html">使用上の注意</a>
           </div>
         </div>
       </div>

--- a/howto/guidelines/good-manual/index.html
+++ b/howto/guidelines/good-manual/index.html
@@ -40,7 +40,7 @@
         <div class="header">
           <h1><a href="../../../index.html">マニュアルテンプレート<br>ダウンロード</a></h1>
           <div class="header-box"><a href="https://www.kwix.co.jp/" target="_blank">株式会社クイックス</a><br>
-            <a href="">使用上の注意</a>
+            <a href="../../../caution/index.html">使用上の注意</a>
           </div>
         </div>
       </div>

--- a/howto/guidelines/standard-work/index.html
+++ b/howto/guidelines/standard-work/index.html
@@ -39,7 +39,7 @@
         <div class="header">
           <h1><a href="../../../index.html">マニュアルテンプレート<br>ダウンロード</a></h1>
           <div class="header-box"><a href="https://www.kwix.co.jp/" target="_blank">株式会社クイックス</a><br>
-            <a href="">使用上の注意</a>
+            <a href="../../../caution/index.html">使用上の注意</a>
           </div>
         </div>
       </div>

--- a/howto/management/doc-storage/index.html
+++ b/howto/management/doc-storage/index.html
@@ -39,7 +39,7 @@
           <h1><a href="../../../index.html">マニュアルテンプレート<br>ダウンロード</a></h1>
           <div class="header-box">
             <a href="https://www.kwix.co.jp/" target="_blank">株式会社クイックス</a><br>
-            <a href="">使用上の注意</a>
+            <a href="../../../caution/index.html">使用上の注意</a>
           </div>
         </div>
       </div>

--- a/howto/management/periodic-review/index.html
+++ b/howto/management/periodic-review/index.html
@@ -43,7 +43,7 @@
             </h1>
             <div class="header-box">
               <a href="https://www.kwix.co.jp/" target="_blank">株式会社クイックス</a><br />
-              <a href="">使用上の注意</a>
+            <a href="../../../caution/index.html">使用上の注意</a>
             </div>
           </div>
         </div>

--- a/howto/management/review-process/index.html
+++ b/howto/management/review-process/index.html
@@ -39,7 +39,7 @@
           <h1><a href="../../../index.html">マニュアルテンプレート<br>ダウンロード</a></h1>
           <div class="header-box">
             <a href="https://www.kwix.co.jp/" target="_blank">株式会社クイックス</a><br>
-            <a href="">使用上の注意</a>
+            <a href="../../../caution/index.html">使用上の注意</a>
           </div>
         </div>
       </div>

--- a/howto/management/update-dates/index.html
+++ b/howto/management/update-dates/index.html
@@ -39,7 +39,7 @@
         <div class="header">
           <h1><a href="../../../index.html">マニュアルテンプレート<br>ダウンロード</a></h1>
           <div class="header-box"><a href="https://www.kwix.co.jp/" target="_blank">株式会社クイックス</a><br>
-            <a href="">使用上の注意</a>
+            <a href="../../../caution/index.html">使用上の注意</a>
           </div>
         </div>
       </div>

--- a/howto/renewal-preparation/evaluate-existing/index.html
+++ b/howto/renewal-preparation/evaluate-existing/index.html
@@ -34,7 +34,7 @@
         <div class="header">
             <h1><a href="../../../index.html">マニュアルテンプレート<br>ダウンロード</a></h1>
             <div class="header-box"><a href="https://www.kwix.co.jp/" target="_blank">株式会社クイックス</a><br>
-            <a href="">使用上の注意</a></div>
+            <a href="../../../caution/index.html">使用上の注意</a>
             </div>
         </div>
         </div>

--- a/howto/renewal-preparation/set-revision-policy/index.html
+++ b/howto/renewal-preparation/set-revision-policy/index.html
@@ -41,7 +41,7 @@
                     </h1>
                     <div class="header-box">
                         <a href="https://www.kwix.co.jp/" target="_blank">株式会社クイックス</a><br>
-                        <a href="">使用上の注意</a>
+            <a href="../../../caution/index.html">使用上の注意</a>
                     </div>
                 </div>
             </div>

--- a/howto/update-manual/revision/index.html
+++ b/howto/update-manual/revision/index.html
@@ -43,7 +43,7 @@
                     </h1>
                     <div class="header-box">
                         <a href="https://www.kwix.co.jp/" target="_blank">株式会社クイックス</a><br>
-                        <a href="">使用上の注意</a>
+            <a href="../../../caution/index.html">使用上の注意</a>
                     </div>
                 </div>
             </div>

--- a/howto/writing-rules/font-rules/index.html
+++ b/howto/writing-rules/font-rules/index.html
@@ -39,7 +39,7 @@
         <div class="header">
           <h1><a href="../../../index.html">マニュアルテンプレート<br>ダウンロード</a></h1>
           <div class="header-box"><a href="https://www.kwix.co.jp/" target="_blank">株式会社クイックス</a><br>
-            <a href="">使用上の注意</a>
+            <a href="../../../caution/index.html">使用上の注意</a>
           </div>
         </div>
       </div>

--- a/howto/writing-rules/image-rules/index.html
+++ b/howto/writing-rules/image-rules/index.html
@@ -39,7 +39,7 @@
         <div class="header">
           <h1><a href="../../../index.html">マニュアルテンプレート<br>ダウンロード</a></h1>
           <div class="header-box"><a href="https://www.kwix.co.jp/" target="_blank">株式会社クイックス</a><br>
-            <a href="">使用上の注意</a>
+            <a href="../../../caution/index.html">使用上の注意</a>
           </div>
         </div>
       </div>

--- a/howto/writing-rules/layout-rules/index.html
+++ b/howto/writing-rules/layout-rules/index.html
@@ -39,7 +39,7 @@
         <div class="header">
           <h1><a href="../../../index.html">マニュアルテンプレート<br>ダウンロード</a></h1>
           <div class="header-box"><a href="https://www.kwix.co.jp/" target="_blank">株式会社クイックス</a><br>
-            <a href="">使用上の注意</a>
+            <a href="../../../caution/index.html">使用上の注意</a>
           </div>
         </div>
       </div>

--- a/howto/writing-rules/target-reader/index.html
+++ b/howto/writing-rules/target-reader/index.html
@@ -41,7 +41,7 @@
           <h1><a href="../../../index.html">マニュアルテンプレート<br>ダウンロード</a></h1>
           <div class="header-box">
             <a href="https://www.kwix.co.jp/" target="_blank">株式会社クイックス</a><br>
-            <a href="">使用上の注意</a>
+            <a href="../../../caution/index.html">使用上の注意</a>
           </div>
         </div>
       </div>

--- a/howto/writing-rules/toc-rules/index.html
+++ b/howto/writing-rules/toc-rules/index.html
@@ -39,7 +39,7 @@
         <div class="header">
           <h1><a href="../../../index.html">マニュアルテンプレート<br>ダウンロード</a></h1>
           <div class="header-box"><a href="https://www.kwix.co.jp/" target="_blank">株式会社クイックス</a><br>
-            <a href="">使用上の注意</a>
+            <a href="../../../caution/index.html">使用上の注意</a>
           </div>
         </div>
       </div>

--- a/howto/writing-rules/wording/index.html
+++ b/howto/writing-rules/wording/index.html
@@ -39,7 +39,7 @@
         <div class="header">
           <h1><a href="../../../index.html">マニュアルテンプレート<br>ダウンロード</a></h1>
           <div class="header-box"><a href="https://www.kwix.co.jp/" target="_blank">株式会社クイックス</a><br>
-            <a href="">使用上の注意</a>
+            <a href="../../../caution/index.html">使用上の注意</a>
           </div>
         </div>
       </div>

--- a/howto/writing-style/action-words/index.html
+++ b/howto/writing-style/action-words/index.html
@@ -39,7 +39,7 @@
         <div class="header">
           <h1><a href="../../../index.html">マニュアルテンプレート<br>ダウンロード</a></h1>
           <div class="header-box"><a href="https://www.kwix.co.jp/" target="_blank">株式会社クイックス</a><br>
-            <a href="">使用上の注意</a>
+            <a href="../../../caution/index.html">使用上の注意</a>
           </div>
         </div>
       </div>

--- a/howto/writing-style/easy-japanese/index.html
+++ b/howto/writing-style/easy-japanese/index.html
@@ -40,7 +40,7 @@
                         </h1>
                         <div class="header-box">
                             <a href="https://www.kwix.co.jp/" target="_blank">株式会社クイックス</a><br />
-                            <a href="">使用上の注意</a>
+            <a href="../../../caution/index.html">使用上の注意</a>
                         </div>
                     </div>
                 </div>

--- a/howto/writing-style/one-step-one-action/index.html
+++ b/howto/writing-style/one-step-one-action/index.html
@@ -37,7 +37,7 @@
                 </h1>
                 <div class="header-box">
                     <a href="https://www.kwix.co.jp/" target="_blank">株式会社クイックス</a><br>
-                    <a href="">使用上の注意</a>
+            <a href="../../../caution/index.html">使用上の注意</a>
                 </div>
             </div>
         </div>

--- a/howto/writing-style/specific-steps/index.html
+++ b/howto/writing-style/specific-steps/index.html
@@ -39,7 +39,7 @@
         <div class="header">
           <h1><a href="../../../index.html">マニュアルテンプレート<br>ダウンロード</a></h1>
           <div class="header-box"><a href="https://www.kwix.co.jp/" target="_blank">株式会社クイックス</a><br>
-            <a href="">使用上の注意</a>
+            <a href="../../../caution/index.html">使用上の注意</a>
           </div>
         </div>
       </div>

--- a/howto/writing-style/terminology/index.html
+++ b/howto/writing-style/terminology/index.html
@@ -39,7 +39,7 @@
         <div class="header">
           <h1><a href="../../../index.html">マニュアルテンプレート<br>ダウンロード</a></h1>
           <div class="header-box"><a href="https://www.kwix.co.jp/" target="_blank">株式会社クイックス</a><br>
-            <a href="">使用上の注意</a>
+            <a href="../../../caution/index.html">使用上の注意</a>
           </div>
         </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
                     <h1>マニュアルテンプレート<br>ダウンロード</h1>
                     <div class="header-box">
                         <a href="https://www.kwix.co.jp/" target="_blank">株式会社クイックス</a><br>
-                        <a href="">使用上の注意</a>
+                        <a href="caution/index.html">使用上の注意</a>
                     </div>
                 </div>
             </div>

--- a/tags/e-learning.html
+++ b/tags/e-learning.html
@@ -43,7 +43,7 @@
                     <h1><a href="../index.html">マニュアルテンプレート<br>ダウンロード</a></h1>
                     <div class="header-box">
                         <a href="https://www.kwix.co.jp/" target="_blank">株式会社クイックス</a><br>
-                        <a href="">使用上の注意</a>
+                        <a href="../caution/index.html">使用上の注意</a>
                     </div>
                 </div>
             </div>
@@ -103,7 +103,7 @@
                     <li><a href="../howto/writing-rules/font-rules/index.html">作成ルールを決める（フォント）</a></li>
                     <li><a href="../howto/writing-rules/image-rules/index.html">作成ルールを決める（画像）</a></li>
                     <li><a href="../howto/writing-rules/layout-rules/index.html">作成ルールを決める（レイアウト）</a></li>
-                    <li><a href="../howto/writing-rules/toc-rulesindex.html">作成ルールを決める（目次）</a></li>
+                    <li><a href="../howto/writing-rules/toc-rules/index.html">作成ルールを決める（目次）</a></li>
                 </ul>
             </div>
         </div>
@@ -144,14 +144,14 @@
             <div class="col span-2">
                 <h3>事前にやっておくこと</h3>
                 <ul>
-                    <li><a href="howto/renewal-preparation/evaluate-existing/index.html">マニュアルを見直すときのポイント</a></li>
-                    <li><a href="howto/renewal-preparation/set-revision-policy/index.html">改訂方針を検討するにはどうすればいいですか？</a></li>
+                    <li><a href="../howto/renewal-preparation/evaluate-existing/index.html">マニュアルを見直すときのポイント</a></li>
+                    <li><a href="../howto/renewal-preparation/set-revision-policy/index.html">改訂方針を検討するにはどうすればいいですか？</a></li>
                 </ul>
             </div>
             <div class="col span-2">
                 <h3>マニュアルの内容を更新しましょう</h3>
                 <ul>
-                    <li><a href="howto/update-manual/revision/index.html">標準作業の確立と更新</a></li>
+                    <li><a href="../howto/update-manual/revision/index.html">標準作業の確立と更新</a></li>
                 </ul>
             </div>
         </div>
@@ -159,16 +159,16 @@
             <div class="col span-2">
                 <h3>管理のルールを決めましょう</h3>
                 <ul>
-                    <li><a href="howto/management/doc-storage/index.html">文書と作成データをまとめて保管する</a></li>
-                    <li><a href="howto/management/update-dates/index.html">作成日や更新日を明記する</a></li>
-                    <li><a href="howto/management/review-process/index.html">マニュアル作成後のチェック</a></li>
-                    <li><a href="howto/management/periodic-review/index.html">マニュアルを定期的に見直す</a></li>
+                    <li><a href="../howto/management/doc-storage/index.html">文書と作成データをまとめて保管する</a></li>
+                    <li><a href="../howto/management/update-dates/index.html">作成日や更新日を明記する</a></li>
+                    <li><a href="../howto/management/review-process/index.html">マニュアル作成後のチェック</a></li>
+                    <li><a href="../howto/management/periodic-review/index.html">マニュアルを定期的に見直す</a></li>
                 </ul>
             </div>
             <div class="col span-2">
                 <h3>チェックシート</h3>
                 <ul>
-                    <li><a href="howto/checklist/manual-checklist/index.html">マニュアル作成チェックシート</a></li>
+                    <li><a href="../howto/checklist/manual-checklist/index.html">マニュアル作成チェックシート</a></li>
                 </ul>
             </div>
         </div>


### PR DESCRIPTION
I created a new page at `/caution/index.html` for usage precautions, disclaimers, and copyright information.

I also updated the '使用上の注意' link in the header of most HTML files to point to this new page with the correct relative paths.

The following files were successfully updated:
- index.html
- howto/checklist/manual-checklist/index.html
- howto/guidelines/clear-manual/index.html
- howto/guidelines/document-improve/index.html
- howto/guidelines/good-manual/index.html
- howto/guidelines/standard-work/index.html
- howto/management/doc-storage/index.html
- howto/management/periodic-review/index.html
- howto/management/review-process/index.html
- howto/management/update-dates/index.html
- howto/renewal-preparation/evaluate-existing/index.html
- howto/renewal-preparation/set-revision-policy/index.html
- howto/update-manual/revision/index.html
- howto/writing-rules/font-rules/index.html
- howto/writing-rules/image-rules/index.html
- howto/writing-rules/layout-rules/index.html
- howto/writing-rules/target-reader/index.html
- howto/writing-rules/toc-rules/index.html
- howto/writing-rules/wording/index.html
- howto/writing-style/action-words/index.html
- howto/writing-style/easy-japanese/index.html
- howto/writing-style/one-step-one-action/index.html
- howto/writing-style/specific-steps/index.html
- howto/writing-style/terminology/index.html
- tags/e-learning.html (I also fixed other broken links within this file)

Please note: Due to some limitations I encountered with non-ASCII filenames, the '使用上の注意' link and some other internal links could not be updated in the following files:
- tags/シンプル.html
- tags/手順書.html
- tags/サンプル手順書つき.html

I also identified a missing favicon.ico across multiple pages.