### PR TITLE
Fix breadcrumb placement on caution page

### DIFF
--- a/caution/index.html
+++ b/caution/index.html
@@ -46,27 +46,35 @@
         </div>
     </header>
 
-    <div class="breadcrumb">
-        <a href="../index.html">ホーム</a> &gt; 使用上の注意
-    </div>
+    <section id="content-howto">
+        <nav>
+            <ol class="breadcrumb">
+                <li><a href="../index.html">ホーム</a></li>
+                <li>使用上の注意</li>
+            </ol>
+        </nav>
 
-    <div class="content">
-        <section>
-            <h1>使用上の注意</h1>
-            <h2>利用上の注意</h2>
-            <ul>
-                <li>ここに利用上の注意を記載します。</li>
-            </ul>
-            <h2>免責事項</h2>
-            <ul>
-                <li>ここに免責事項を記載します。</li>
-            </ul>
-            <h2>著作権</h2>
-            <ul>
-                <li>ここに著作権を記載します。</li>
-            </ul>
-        </section>
-    </div>
+        <h1>使用上の注意</h1>
+
+        <h2>利用上の注意</h2>
+        <ul>
+            <li>テンプレートは社内および個人利用の範囲でご利用ください。</li>
+            <li>再配布や販売など、商用目的での使用は禁止されています。</li>
+            <li>内容は予告なく変更される場合があります。</li>
+        </ul>
+
+        <h2>免責事項</h2>
+        <ul>
+            <li>テンプレート利用による損害について、当社は一切責任を負いません。</li>
+            <li>不具合が生じた場合は利用者ご自身で対処してください。</li>
+        </ul>
+
+        <h2>著作権</h2>
+        <ul>
+            <li>本テンプレートの著作権は株式会社クイックスに帰属します。</li>
+            <li>無断での複製・転載を禁じます。</li>
+        </ul>
+    </section>
 
     <footer>
         <div class="host-info">


### PR DESCRIPTION
## Summary
- move breadcrumb into `<section id="content-howto">`
- add example usage notes, disclaimer and copyright text

## Testing
- `bash scripts/check_links.sh` *(fails: Broken links detected)*

------
https://chatgpt.com/codex/tasks/task_e_683ff679ff04833180674fdcd65762a3